### PR TITLE
update preview workflow action versions

### DIFF
--- a/.github/workflows/astro-preview.yml
+++ b/.github/workflows/astro-preview.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
Bump GitHub Actions from v4 to v5 for checkout and setup-node to eliminate the Node 20 deprecation warning on runners.