### PR TITLE
exclude astro source from pages build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,3 +17,5 @@ url: "http://clay.yale.edu/" # the base hostname & protocol for your site
 
 # Build settings
 markdown: kramdown
+exclude:
+  - astro-site


### PR DESCRIPTION
Prevent GitHub Pages Jekyll branch builds from parsing Astro .astro files by excluding the astro-site directory in root Jekyll config.