### PR TITLE
fix preview trailing-slash redirect loop

### DIFF
--- a/astro-site/src/config.preview.yaml
+++ b/astro-site/src/config.preview.yaml
@@ -2,7 +2,7 @@ site:
   name: CLAY Lab
   site: 'https://clay.yale.edu'
   base: '/preview/'
-  trailingSlash: false
+  trailingSlash: true
 
   googleSiteVerificationId: null
 


### PR DESCRIPTION
Set preview config trailingSlash to true so generated /preview/index.html is an actual page instead of a redirect to /preview, which loops on GitHub Pages branch deployments.