### PR TITLE
include preview assets in pages build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,3 +19,5 @@ url: "http://clay.yale.edu/" # the base hostname & protocol for your site
 markdown: kramdown
 exclude:
   - astro-site
+include:
+  - preview/_astro


### PR DESCRIPTION
Jekyll branch deploys ignore underscore-prefixed folders by default, which dropped /preview/_astro and caused CSS/JS 404s. Include preview/_astro explicitly so preview styling and scripts load.